### PR TITLE
Update GitHub Actions workflow permissions for improved access control

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  id-token: write
+  contents: read
+
 concurrency:
   group: main
   cancel-in-progress: true


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/build.yml` file. The change adds permissions for `id-token` and `contents` to the workflow configuration.

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R8-R11): Added `permissions` section to grant `id-token: write` and `contents: read` permissions.