### PR TITLE
fix(typo): Update GitHub Actions build workflow to use ECR registry \for Docker image management

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,5 +49,5 @@ jobs:
           DJANGO_SUPERUSER_PASSWORD: ${{ secrets.DJANGO_SUPERUSER_PASSWORD }}
           DJANGO_SUPERUSER_EMAIL: ${{ secrets.DJANGO_SUPERUSER_EMAIL }}
         run: |
-          docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG .
-          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+          docker build -t $ECR_REGISTRY/$REPOSITORY_NAME:$IMAGE_TAG .
+          docker push $ECR_REGISTRY/$REPOSITORY_NAME:$IMAGE_TAG


### PR DESCRIPTION
This pull request includes a change to the `jobs:` section in the `.github/workflows/build.yml` file. The change updates the Docker build and push commands to use new environment variables for the ECR registry and repository name.

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L52-R53): Updated Docker build and push commands to use `$ECR_REGISTRY` and `$REPOSITORY_NAME` instead of `$REGISTRY` and `$REPOSITORY`.…