### PR TITLE
feat(docker): Enhance entrypoint script with debug logging for superuser credentials and allowed hosts

### DIFF
--- a/scripts/docker.entrypoint.sh
+++ b/scripts/docker.entrypoint.sh
@@ -3,14 +3,23 @@
 set -e
 
 cd /app
-/root/.local/bin/poetry run python3 -m pip install uvicorn-worker
 
 RUN_MANAGE_PY='/root/.local/bin/poetry run python -m src.manage'
 
 echo 'Running migrations...'
 $RUN_MANAGE_PY migrate --no-input
 
+echo '[DEBUG] printing DJANGO_SUPERUSER_USERNAME and DJANGO_SUPERUSER_PASSWORD'
+echo "DJANGO_SUPERUSER_USERNAME=$DJANGO_SUPERUSER_USERNAME"
+echo "DJANGO_SUPERUSER_PASSWORD=$DJANGO_SUPERUSER_PASSWORD"
+echo '[DEBUG] end printing DJANGO_SUPERUSER_USERNAME and DJANGO_SUPERUSER_PASSWORD'
+
 echo 'Creating superuser...'
 $RUN_MANAGE_PY createsuperuser --no-input || echo 'Superuser already exists.'
 
-exec make deploy
+echo "[DEBUG] printing ALLOWED_HOSTS"
+echo  "ALLOWED_HOSTS=$ALLOWED_HOSTS"
+echo  "TXT_SINK_SETTINGS_ALLOWED_HOSTS=$TXT_SINK_SETTINGS_ALLOWED_HOSTS"
+echo "[DEBUG] end printing ALLOWED_HOSTS"
+
+exec $RUN_MANAGE_PY run gunicorn src.core.asgi:application -k uvicorn_worker.UvicornWorker


### PR DESCRIPTION
This pull request includes updates to the `scripts/docker.entrypoint.sh` file, primarily focusing on adding debug statements and modifying the way the application is started.

Debugging improvements:

* Added debug statements to print `DJANGO_SUPERUSER_USERNAME` and `DJANGO_SUPERUSER_PASSWORD` for troubleshooting purposes.
* Added debug statements to print `ALLOWED_HOSTS` and `TXT_SINK_SETTINGS_ALLOWED_HOSTS` for better visibility into environment variables.

Application startup changes:

* Changed the application startup command to use `gunicorn` with `uvicorn_worker` instead of the `make deploy` command.