### PR TITLE
feat(docker): Rearrange debug logging for allowed hosts and superuser credentials in entrypoint script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
   push:
     name: Push image to ECR
     needs: quality-assurance
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   quality-assurance:
     name: Quality Assurance
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       max-parallel: 4
       matrix:

--- a/scripts/docker.entrypoint.sh
+++ b/scripts/docker.entrypoint.sh
@@ -6,20 +6,20 @@ cd /app
 
 RUN_MANAGE_PY='/root/.local/bin/poetry run python -m src.manage'
 
-echo 'Running migrations...'
-$RUN_MANAGE_PY migrate --no-input
+echo "[DEBUG] printing ALLOWED_HOSTS"
+echo  "ALLOWED_HOSTS=$ALLOWED_HOSTS"
+echo  "TXT_SINK_SETTINGS_ALLOWED_HOSTS=$TXT_SINK_SETTINGS_ALLOWED_HOSTS"
+echo "[DEBUG] end printing ALLOWED_HOSTS"
 
 echo '[DEBUG] printing DJANGO_SUPERUSER_USERNAME and DJANGO_SUPERUSER_PASSWORD'
 echo "DJANGO_SUPERUSER_USERNAME=$DJANGO_SUPERUSER_USERNAME"
 echo "DJANGO_SUPERUSER_PASSWORD=$DJANGO_SUPERUSER_PASSWORD"
 echo '[DEBUG] end printing DJANGO_SUPERUSER_USERNAME and DJANGO_SUPERUSER_PASSWORD'
 
+echo 'Running migrations...'
+$RUN_MANAGE_PY migrate --no-input
+
 echo 'Creating superuser...'
 $RUN_MANAGE_PY createsuperuser --no-input || echo 'Superuser already exists.'
-
-echo "[DEBUG] printing ALLOWED_HOSTS"
-echo  "ALLOWED_HOSTS=$ALLOWED_HOSTS"
-echo  "TXT_SINK_SETTINGS_ALLOWED_HOSTS=$TXT_SINK_SETTINGS_ALLOWED_HOSTS"
-echo "[DEBUG] end printing ALLOWED_HOSTS"
 
 exec $RUN_MANAGE_PY run gunicorn src.core.asgi:application -k uvicorn_worker.UvicornWorker


### PR DESCRIPTION
This pull request includes a small change to the `scripts/docker.entrypoint.sh` file. The change reorders the debug print statements for `ALLOWED_HOSTS` and `TXT_SINK_SETTINGS_ALLOWED_HOSTS` to run before the database migrations and superuser creation steps. 

Debugging improvements:

* [`scripts/docker.entrypoint.sh`](diffhunk://#diff-0d59dc4cd8776a5cf965e605f7b535efc61f36a1ab82e5514449f8e07b887ba6L9-L24): Moved debug print statements for `ALLOWED_HOSTS` and `TXT_SINK_SETTINGS_ALLOWED_HOSTS` to execute before running migrations and creating the superuser.