### PR TITLE
feat(middlewares): Add middleware to dynamically manage ALLOWED_HOSTS  from ALB subnet

### DIFF
--- a/src/core/middlewares.py
+++ b/src/core/middlewares.py
@@ -1,0 +1,23 @@
+"""Middleware to add dynamic hosts to ALLOWED_HOSTS from our alb subnet"""
+
+from django.conf import settings
+from django.core.exceptions import DisallowedHost
+
+TXT_SINK_APP_SUBNET_A_CIDR_PREFIX = "10.0.10."
+TXT_SINK_APP_SUBNET_B_CIDR_PREFIX = "10.0.11."
+
+
+class ALBSubnetDynamicAllowedHostsMiddleware:
+    """ Middleware to add dynamic hosts to ALLOWED_HOSTS from our alb subnet """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        host = request.get_host().split(":")[0]
+        if not host.startswith(TXT_SINK_APP_SUBNET_A_CIDR_PREFIX
+                               ) or not host.startswith(TXT_SINK_APP_SUBNET_B_CIDR_PREFIX):
+            raise DisallowedHost("Host not allowed")
+        if host and host not in settings.ALLOWED_HOSTS:
+            settings.ALLOWED_HOSTS.append(host)
+        return self.get_response(request)

--- a/src/core/settings/base.py
+++ b/src/core/settings/base.py
@@ -43,6 +43,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "corsheaders.middleware.CorsMiddleware",
+    "src.core.middlewares.ALBSubnetDynamicAllowedHostsMiddleware",
 ]
 
 ROOT_URLCONF = "src.core.urls"


### PR DESCRIPTION
This pull request introduces a new middleware to dynamically add hosts from specific subnets to the `ALLOWED_HOSTS` setting in a Django application. The most important changes include the addition of the middleware class and its integration into the middleware stack.

Middleware addition:

* [`src/core/middlewares.py`](diffhunk://#diff-963f20f4732394b57e3e7f70f5a2fb571efe0cef17d8105388ab00b5f1fc892aR1-R23): Added `ALBSubnetDynamicAllowedHostsMiddleware` to dynamically add hosts from specific subnets (`TXT_SINK_APP_SUBNET_A_CIDR_PREFIX` and `TXT_SINK_APP_SUBNET_B_CIDR_PREFIX`) to `ALLOWED_HOSTS`.

Middleware integration:

* [`src/core/settings/base.py`](diffhunk://#diff-49443750baa2de3e7a72c5b6188401406d866468af0ef72440480281bec39df0R46): Integrated `ALBSubnetDynamicAllowedHostsMiddleware` into the Django middleware stack.