### PR TITLE
feat(docker): Update entry point to bind Gunicorn to dynamic port from environment variable

### DIFF
--- a/scripts/docker.entrypoint.sh
+++ b/scripts/docker.entrypoint.sh
@@ -23,5 +23,5 @@ echo 'Creating superuser...'
 DJANGO_SUPERUSER_PASSWORD=$TXT_SINK_SETTINGS_DJANGO_SUPERUSER_PASSWORD $RUN_MANAGE_PY createsuperuser --no-input \
 --username $TXT_SINK_SETTINGS_DJANGO_SUPERUSER_USERNAME --email $TXT_SINK_SETTINGS_DJANGO_SUPERUSER_EMAIL || echo 'Superuser already exists.'
 
-exec /root/.local/bin/poetry run gunicorn src.core.asgi:application -k uvicorn_worker.UvicornWorker 
+exec /root/.local/bin/poetry run gunicorn src.core.asgi:application -k uvicorn_worker.UvicornWorker -b :$GUNICORN_PORT
 


### PR DESCRIPTION
This pull request includes a small change to the `scripts/docker.entrypoint.sh` file. The change modifies the command to run the Gunicorn server by adding a binding option for the port.

* [`scripts/docker.entrypoint.sh`](diffhunk://#diff-0d59dc4cd8776a5cf965e605f7b535efc61f36a1ab82e5514449f8e07b887ba6L26-R26): Modified the Gunicorn command to include the `-b :$GUNICORN_PORT` option, allowing the server to bind to a specified port.