### PR TITLE
feat(docker): Remove debug echo statements and bind Gunicorn to dynamic port from namespaced environment variable

### DIFF
--- a/scripts/docker.entrypoint.sh
+++ b/scripts/docker.entrypoint.sh
@@ -6,16 +6,6 @@ cd /app
 
 RUN_MANAGE_PY='/root/.local/bin/poetry run python -m src.manage'
 
-echo "[DEBUG] printing ALLOWED_HOSTS"
-echo  "ALLOWED_HOSTS=$ALLOWED_HOSTS"
-echo  "TXT_SINK_SETTINGS_ALLOWED_HOSTS=$TXT_SINK_SETTINGS_ALLOWED_HOSTS"
-echo "[DEBUG] end printing ALLOWED_HOSTS"
-
-echo '[DEBUG] printing DJANGO_SUPERUSER_USERNAME and DJANGO_SUPERUSER_PASSWORD'
-echo "DJANGO_SUPERUSER_USERNAME=$DJANGO_SUPERUSER_USERNAME"
-echo "DJANGO_SUPERUSER_PASSWORD=$DJANGO_SUPERUSER_PASSWORD"
-echo '[DEBUG] end printing DJANGO_SUPERUSER_USERNAME and DJANGO_SUPERUSER_PASSWORD'
-
 echo 'Running migrations...'
 $RUN_MANAGE_PY migrate --no-input
 
@@ -23,5 +13,5 @@ echo 'Creating superuser...'
 DJANGO_SUPERUSER_PASSWORD=$TXT_SINK_SETTINGS_DJANGO_SUPERUSER_PASSWORD $RUN_MANAGE_PY createsuperuser --no-input \
 --username $TXT_SINK_SETTINGS_DJANGO_SUPERUSER_USERNAME --email $TXT_SINK_SETTINGS_DJANGO_SUPERUSER_EMAIL || echo 'Superuser already exists.'
 
-exec /root/.local/bin/poetry run gunicorn src.core.asgi:application -k uvicorn_worker.UvicornWorker -b :$GUNICORN_PORT
+exec /root/.local/bin/poetry run gunicorn src.core.asgi:application -k uvicorn_worker.UvicornWorker -b :$TXT_SINK_SETTINGS_GUNICORN_PORT
 


### PR DESCRIPTION
This pull request includes changes to the `scripts/docker.entrypoint.sh` file to remove debug print statements and modify the port configuration for the Gunicorn server. 

The most important changes include:

* Removed debug print statements for `ALLOWED_HOSTS`, `DJANGO_SUPERUSER_USERNAME`, and `DJANGO_SUPERUSER_PASSWORD` to clean up the script output.
* Changed the Gunicorn server to use the `TXT_SINK_SETTINGS_GUNICORN_PORT` environment variable instead of a hardcoded port value.