### PR TITLE
feat(middlewares): Pull ALBSubnetDynamicAllowedHostsMiddleware to top of middleware stack

### DIFF
--- a/src/core/settings/base.py
+++ b/src/core/settings/base.py
@@ -35,6 +35,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    "src.core.middlewares.ALBSubnetDynamicAllowedHostsMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -43,7 +44,6 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "corsheaders.middleware.CorsMiddleware",
-    "src.core.middlewares.ALBSubnetDynamicAllowedHostsMiddleware",
 ]
 
 ROOT_URLCONF = "src.core.urls"


### PR DESCRIPTION
This pull request includes changes to the `src/core/settings/base.py` file to adjust the middleware configurations. The most important change involves the reordering of the `ALBSubnetDynamicAllowedHostsMiddleware`.

Middleware configuration changes:

* [`src/core/settings/base.py`](diffhunk://#diff-49443750baa2de3e7a72c5b6188401406d866468af0ef72440480281bec39df0R38): Pull up `ALBSubnetDynamicAllowedHostsMiddleware` to the beginning of the `MIDDLEWARE` list to ensure it runs before other middlewares.
