### PR TITLE
feat(middlewares): Enhance ALLOWED_HOSTS handling with dynamic IP fetching and CIDR ranges

### DIFF
--- a/scripts/docker.entrypoint.sh
+++ b/scripts/docker.entrypoint.sh
@@ -13,5 +13,29 @@ echo 'Creating superuser...'
 DJANGO_SUPERUSER_PASSWORD=$TXT_SINK_SETTINGS_DJANGO_SUPERUSER_PASSWORD $RUN_MANAGE_PY createsuperuser --no-input \
 --username $TXT_SINK_SETTINGS_DJANGO_SUPERUSER_USERNAME --email $TXT_SINK_SETTINGS_DJANGO_SUPERUSER_EMAIL || echo 'Superuser already exists.'
 
-exec /root/.local/bin/poetry run gunicorn src.core.asgi:application -k uvicorn_worker.UvicornWorker -b :$TXT_SINK_SETTINGS_GUNICORN_PORT
+echo "Fetching IP addresses..."
+HOST_IPS=$(hostname -I)
+IFS=' ' read -r -a HOST_IP_ARRAY <<< "$HOST_IPS"
+
+ALLOWED_HOSTS="[$TXT_SINK_SETTINGS_ALLOWED_HOSTS"
+for HOST_IP in "${HOST_IP_ARRAY[@]}"; do
+  ALLOWED_HOSTS="$ALLOWED_HOSTS, '$HOST_IP'"
+done
+
+# Append CIDR range 10.0.10.0/24 and range 10.0.11.0/24
+for i in {0..255}; do
+  ALLOWED_HOSTS="$ALLOWED_HOSTS, '10.0.10.$i'"
+  ALLOWED_HOSTS="$ALLOWED_HOSTS, '10.0.11.$i'"
+done
+
+ALLOWED_HOSTS="$ALLOWED_HOSTS]"
+
+# Export ALLOWED_HOSTS
+export ALLOWED_HOSTS
+
+echo "Updated ALLOWED_HOSTS#Count=${#ALLOWED_HOSTS}"
+
+# Pass environment variable to Gunicorn
+TXT_SINK_SETTINGS_ALLOWED_HOSTS="$ALLOWED_HOSTS" exec  /root/.local/bin/poetry run gunicorn src.core.asgi:application -k uvicorn_worker.UvicornWorker -b :$TXT_SINK_SETTINGS_GUNICORN_PORT
+
 

--- a/src/core/middlewares.py
+++ b/src/core/middlewares.py
@@ -1,7 +1,6 @@
 """Middleware to add dynamic hosts to ALLOWED_HOSTS from our alb subnet"""
 
 from django.conf import settings
-from django.core.exceptions import DisallowedHost
 
 TXT_SINK_APP_SUBNET_A_CIDR_PREFIX = "10.0.10."
 TXT_SINK_APP_SUBNET_B_CIDR_PREFIX = "10.0.11."
@@ -14,10 +13,10 @@ class ALBSubnetDynamicAllowedHostsMiddleware:
         self.get_response = get_response
 
     def __call__(self, request):
+        print("[__call__] ALLOWED: ", settings.ALLOWED_HOSTS)
         host = request.get_host().split(":")[0]
-        if not host.startswith(TXT_SINK_APP_SUBNET_A_CIDR_PREFIX
-                               ) or not host.startswith(TXT_SINK_APP_SUBNET_B_CIDR_PREFIX):
-            raise DisallowedHost("Host not allowed")
-        if host and host not in settings.ALLOWED_HOSTS:
+        if (
+            host.startswith(TXT_SINK_APP_SUBNET_A_CIDR_PREFIX) or host.startswith(TXT_SINK_APP_SUBNET_B_CIDR_PREFIX)
+        ) and host not in settings.ALLOWED_HOSTS:
             settings.ALLOWED_HOSTS.append(host)
         return self.get_response(request)


### PR DESCRIPTION
This pull request includes changes to dynamically update the `ALLOWED_HOSTS` setting in the Django application and modify the middleware to handle these updates. The most important changes are detailed below:

### Dynamic `ALLOWED_HOSTS` Update:

* [`scripts/docker.entrypoint.sh`](diffhunk://#diff-0d59dc4cd8776a5cf965e605f7b535efc61f36a1ab82e5514449f8e07b887ba6L16-R40): Added logic to fetch host IP addresses, append specific CIDR ranges, and update the `ALLOWED_HOSTS` environment variable before starting the Gunicorn server.

### Middleware Adjustments:

* [`src/core/middlewares.py`](diffhunk://#diff-963f20f4732394b57e3e7f70f5a2fb571efe0cef17d8105388ab00b5f1fc892aL4): Removed the `DisallowedHost` exception and modified the logic to dynamically add hosts from the specified subnets to the `ALLOWED_HOSTS` list if they are not already present. [[1]](diffhunk://#diff-963f20f4732394b57e3e7f70f5a2fb571efe0cef17d8105388ab00b5f1fc892aL4) [[2]](diffhunk://#diff-963f20f4732394b57e3e7f70f5a2fb571efe0cef17d8105388ab00b5f1fc892aR16-R20)