### PR TITLE
feat(docker): Refactor ALLOWED_HOSTS handling to remove brackets and format IPs correctly

### DIFF
--- a/scripts/docker.entrypoint.sh
+++ b/scripts/docker.entrypoint.sh
@@ -17,7 +17,13 @@ echo "Fetching IP addresses..."
 HOST_IPS=$(hostname -I)
 IFS=' ' read -r -a HOST_IP_ARRAY <<< "$HOST_IPS"
 
-ALLOWED_HOSTS="[$TXT_SINK_SETTINGS_ALLOWED_HOSTS"
+# Remove the initial and final square brackets from TXT_SINK_SETTINGS_ALLOWED_HOSTS
+TXT_SINK_SETTINGS_ALLOWED_HOSTS=${TXT_SINK_SETTINGS_ALLOWED_HOSTS:1:-1}
+
+# surround each element with single quotes
+TXT_SINK_SETTINGS_ALLOWED_HOSTS=$(echo $TXT_SINK_SETTINGS_ALLOWED_HOSTS | sed "s/,/','/g")
+
+ALLOWED_HOSTS="['${TXT_SINK_SETTINGS_ALLOWED_HOSTS//,/','}'"
 for HOST_IP in "${HOST_IP_ARRAY[@]}"; do
   ALLOWED_HOSTS="$ALLOWED_HOSTS, '$HOST_IP'"
 done


### PR DESCRIPTION
This pull request includes a change to the `scripts/docker.entrypoint.sh` file to modify how `TXT_SINK_SETTINGS_ALLOWED_HOSTS` is processed. The change ensures that the variable is correctly formatted by removing the initial and final square brackets and surrounding each element with single quotes.

Formatting changes to `TXT_SINK_SETTINGS_ALLOWED_HOSTS`:

* Removed the initial and final square brackets from `TXT_SINK_SETTINGS_ALLOWED_HOSTS` to avoid syntax issues.
* Added single quotes around each element in `TXT_SINK_SETTINGS_ALLOWED_HOSTS` to ensure proper formatting.