### PR TITLE
feat(middlewares): Add debug logging for settings and include SECRET_KEY in Gunicorn execution

### DIFF
--- a/scripts/docker.entrypoint.sh
+++ b/scripts/docker.entrypoint.sh
@@ -42,6 +42,6 @@ export ALLOWED_HOSTS
 echo "Updated ALLOWED_HOSTS#Count=${#ALLOWED_HOSTS}"
 
 # Pass environment variable to Gunicorn
-TXT_SINK_SETTINGS_ALLOWED_HOSTS="$ALLOWED_HOSTS" exec  /root/.local/bin/poetry run gunicorn src.core.asgi:application -k uvicorn_worker.UvicornWorker -b :$TXT_SINK_SETTINGS_GUNICORN_PORT
+TXT_SINK_SETTINGS_ALLOWED_HOSTS="$ALLOWED_HOSTS" SECRET_KEY="$TXT_SINK_SETTINGS_SECRET_KEY" exec  /root/.local/bin/poetry run gunicorn src.core.asgi:application -k uvicorn_worker.UvicornWorker -b :$TXT_SINK_SETTINGS_GUNICORN_PORT
 
 

--- a/src/core/middlewares.py
+++ b/src/core/middlewares.py
@@ -13,7 +13,11 @@ class ALBSubnetDynamicAllowedHostsMiddleware:
         self.get_response = get_response
 
     def __call__(self, request):
-        print("[__call__] ALLOWED: ", settings.ALLOWED_HOSTS)
+        for key in dir(settings):
+            value = getattr(settings, key)
+            if key.isupper():
+                print("[DEBUG][__call__]: " + key + " = " + value)
+
         host = request.get_host().split(":")[0]
         if (
             host.startswith(TXT_SINK_APP_SUBNET_A_CIDR_PREFIX) or host.startswith(TXT_SINK_APP_SUBNET_B_CIDR_PREFIX)


### PR DESCRIPTION
This pull request includes changes to enhance the handling and debugging of environment variables in the application. The most important changes involve updating the `docker.entrypoint.sh` script to include an additional environment variable and improving the logging in the middleware for better debugging.

Enhancements to environment variable handling:

* [`scripts/docker.entrypoint.sh`](diffhunk://#diff-0d59dc4cd8776a5cf965e605f7b535efc61f36a1ab82e5514449f8e07b887ba6L45-R45): Added `SECRET_KEY` environment variable to the Gunicorn execution command to ensure it is passed correctly.

Improvements to debugging:

* [`src/core/middlewares.py`](diffhunk://#diff-963f20f4732394b57e3e7f70f5a2fb571efe0cef17d8105388ab00b5f1fc892aL16-R20): Enhanced the `__call__` method to print all uppercase settings variables and their values for better debugging information.