### PR TITLE
fix(middlewares): Update debug logging format for improved readability

### DIFF
--- a/src/core/middlewares.py
+++ b/src/core/middlewares.py
@@ -16,7 +16,7 @@ class ALBSubnetDynamicAllowedHostsMiddleware:
         for key in dir(settings):
             value = getattr(settings, key)
             if key.isupper():
-                print("[DEBUG][__call__]: " + key + " = " + value)
+                print("[DEBUG][__call__]: ", key, " = ", value)
 
         host = request.get_host().split(":")[0]
         if (


### PR DESCRIPTION
This pull request includes a minor change to the `__call__` method in the `src/core/middlewares.py` file. The change modifies the way debug information is printed, switching from string concatenation to using multiple arguments in the `print` function.

* [`src/core/middlewares.py`](diffhunk://#diff-963f20f4732394b57e3e7f70f5a2fb571efe0cef17d8105388ab00b5f1fc892aL19-R19): Modified the debug print statement in the `__call__` method to use multiple arguments instead of string concatenation.