### PR TITLE
feat(ci): Rename workflow to CD Workflow and enhance ECR image tagging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Continuous Integration
+name: CD Workflow
 
 on:
   push:
@@ -31,14 +31,12 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: us-east-1
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
-        with:
-          ecr-registry: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       - name: Build, tag, and push docker image to Amazon ECR
         env :
@@ -50,4 +48,6 @@ jobs:
           DJANGO_SUPERUSER_EMAIL: ${{ secrets.DJANGO_SUPERUSER_EMAIL }}
         run: |
           docker build -t $ECR_REGISTRY/$REPOSITORY_NAME:$IMAGE_TAG .
+          docker tag $ECR_REGISTRY/$REPOSITORY_NAME:$IMAGE_TAG $ECR_REGISTRY/$REPOSITORY_NAME:latest
           docker push $ECR_REGISTRY/$REPOSITORY_NAME:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$REPOSITORY_NAME:latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,4 +1,4 @@
-name: Quality Assurance
+name: CI Workflow
 
 on: 
   push:


### PR DESCRIPTION
This pull request includes changes to the GitHub workflows to enhance the continuous deployment and integration processes. The most important changes are related to renaming workflows, updating AWS credentials, and modifying Docker commands.

Workflow renaming:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L1-R1): Renamed the workflow from "Continuous Integration" to "CD Workflow".
* [`.github/workflows/pr.yml`](diffhunk://#diff-15c806aa509538190832852f439e9921a23bec2da81f95ed0e4bf13c14e5b160L1-R1): Renamed the workflow from "Quality Assurance" to "CI Workflow".

AWS credentials update:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R34-L41): Added `aws-access-key-id` and `aws-secret-access-key` under the `with` section for role assumption.

Docker commands modification:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R51-R53): Added commands to tag the Docker image with `latest` and push it to the Amazon ECR repository.