### PR TITLE
fix(ci): Remove AWS access keys from workflow for enhanced security

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,8 +31,6 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: us-east-1
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       - name: Login to Amazon ECR
         id: login-ecr


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/build.yml` file. The change removes the `aws-access-key-id` and `aws-secret-access-key` parameters from the `jobs:` section.

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L34-L35): Removed `aws-access-key-id` and `aws-secret-access-key` parameters from the `jobs:` section.