### PR TITLE
Add ECR login output and set AWS region for build workflow

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -31,6 +31,8 @@ jobs:
     name: Prebuild
     needs: [quality-assurance, aws-config]
     runs-on: ubuntu-24.04
+    outputs:
+      login-ecr: ${{ steps.login-ecr.outputs }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -38,6 +40,8 @@ jobs:
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
+        env:
+          AWS_REGION: us-east-1
         
 
   build:


### PR DESCRIPTION
Include ECR login output in the workflow and specify the AWS region for the build process.