### PR TITLE
Refactor CI to streamline prebuild job output

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -21,8 +21,6 @@ jobs:
     name: Prebuild
     needs: quality-assurance
     runs-on: ubuntu-24.04
-    outputs:
-      login-ecr: ${{ steps.login-ecr.outputs }}
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
Remove unnecessary output from the prebuild job in the build_and_deploy workflow to simplify the process.