### PR TITLE
Add ECR login output to prebuild job in build_and_deploy workflow

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -21,6 +21,8 @@ jobs:
     name: Prebuild
     needs: quality-assurance
     runs-on: ubuntu-24.04
+    outputs:
+      login-ecr: ${{ steps.login-ecr.outputs }}
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
Include ECR login output in the prebuild job to enhance the build and deployment process.