### PR TITLE
Restore ECR login output in build_and_deploy workflow

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -21,8 +21,6 @@ jobs:
     name: Prebuild
     needs: quality-assurance
     runs-on: ubuntu-24.04
-    outputs:
-      login-ecr: ${{ steps.login-ecr.outputs }}
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -36,6 +34,8 @@ jobs:
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
+    outputs:
+      login-ecr: ${{ steps.login-ecr.outputs }}
 
   build:
     name: Build


### PR DESCRIPTION
Restore the output for ECR login in the prebuild job to ensure it can be utilized in subsequent steps of the workflow.