### PR TITLE
fix(ci): Remove virtual environment activation step from PR workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -38,9 +38,6 @@ jobs:
         path: ./.venv
         key: venv-${{ hashFiles('poetry.lock') }}
 
-    - name: Activate the virtual environment
-      run: source .venv/bin/activate
-
     - name: Install Dependencies
       run: poetry install --no-root
 
@@ -52,4 +49,4 @@ jobs:
         mkdir -p local
         cp src/core/settings/templates/settings.unittests.py ./local/settings.unittests.py
         export PYTHONPATH=$PYTHONPATH:/home/runner/work/txt-sink-api/txt-sink-api/src
-        ls -alh &&  make test
+        make test


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/pr.yml` file to streamline the workflow by removing unnecessary steps and simplifying commands.

Workflow simplification:

* Removed the step to activate the virtual environment, as it is not needed for the subsequent steps. (`.github/workflows/pr.yml`, [.github/workflows/pr.ymlL41-L43](diffhunk://#diff-15c806aa509538190832852f439e9921a23bec2da81f95ed0e4bf13c14e5b160L41-L43))
* Simplified the command to run tests by removing the redundant `ls -alh` command. (`.github/workflows/pr.yml`, [.github/workflows/pr.ymlL55-R52](diffhunk://#diff-15c806aa509538190832852f439e9921a23bec2da81f95ed0e4bf13c14e5b160L55-R52))